### PR TITLE
Prevent cube edges from becoming weirdly long

### DIFF
--- a/flashycubes.js
+++ b/flashycubes.js
@@ -234,6 +234,7 @@ var flashycubes = {};
 
   function drawCube() {
     gfx.lineWidth = lineWidth;
+    gfx.lineJoin = 'bevel';
     gfx.strokeStyle = rgba(low * 255, mid * 128, high * 128,
       0.8 + amplitude);
     strokeCube(parallax[0], parallax[1], 4, 1 + amplitude,


### PR DESCRIPTION
Changes [the `lineJoin` property][lj] to 'bevel'. The default is 'miter'.

[lj]: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineJoin